### PR TITLE
Replace UnmanagedExports.Repack with DllExport

### DIFF
--- a/DotNetPlugin.Impl/DotNetPlugin.Impl.csproj
+++ b/DotNetPlugin.Impl/DotNetPlugin.Impl.csproj
@@ -35,9 +35,6 @@
   <ItemGroup>
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.18.2" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />
-    <PackageReference Include="UnmanagedExports.Repack" Version="1.0.4">
-      <IncludeAssets>build</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/DotNetPlugin.Stub/DotNetPlugin.Stub.csproj
+++ b/DotNetPlugin.Stub/DotNetPlugin.Stub.csproj
@@ -59,10 +59,4 @@
     </ItemGroup>
   </Target>
 
-  <ItemGroup>
-    <PackageReference Include="UnmanagedExports.Repack" Version="1.0.4">
-      <!-- Suppress actual IL rewriting because we want to do that at a later stage (see DotNetPlugin.Impl) -->
-      <ExcludeAssets>build</ExcludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/DotNetPlugin.Stub/PluginMain.cs
+++ b/DotNetPlugin.Stub/PluginMain.cs
@@ -4,7 +4,6 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using DotNetPlugin.NativeBindings.SDK;
-using RGiesecke.DllExport;
 
 namespace DotNetPlugin
 {

--- a/DotNetPlugin.Stub/PluginMain.cs
+++ b/DotNetPlugin.Stub/PluginMain.cs
@@ -206,7 +206,7 @@ namespace DotNetPlugin
         }
 #endif
 
-        [DllExport("pluginit", CallingConvention.Cdecl)]
+        [System.Runtime.InteropServices.DllExport("pluginit", CallingConvention.Cdecl)]
         public static bool pluginit(ref Plugins.PLUG_INITSTRUCT initStruct)
         {
             if (!TryLoadPlugin(isInitial: true))
@@ -236,7 +236,7 @@ namespace DotNetPlugin
             return true;
         }
 
-        [DllExport("plugsetup", CallingConvention.Cdecl)]
+        [System.Runtime.InteropServices.DllExport("plugsetup", CallingConvention.Cdecl)]
         private static void plugsetup(ref Plugins.PLUG_SETUPSTRUCT setupStruct)
         {
             s_setupStruct = setupStruct;
@@ -244,7 +244,7 @@ namespace DotNetPlugin
             Session.Setup(ref setupStruct);
         }
 
-        [DllExport("plugstop", CallingConvention.Cdecl)]
+        [System.Runtime.InteropServices.DllExport("plugstop", CallingConvention.Cdecl)]
         private static bool plugstop()
         {
             var success = Session.Stop();
@@ -279,7 +279,7 @@ namespace DotNetPlugin
         }
 #endif
 
-        [DllExport("CBMENUENTRY", CallingConvention.Cdecl)]
+        [System.Runtime.InteropServices.DllExport("CBMENUENTRY", CallingConvention.Cdecl)]
         public static void CBMENUENTRY(Plugins.CBTYPE cbType, ref Plugins.PLUG_CB_MENUENTRY info)
         {
             Session.OnMenuEntry(ref info);

--- a/README.md
+++ b/README.md
@@ -78,13 +78,24 @@ https://github.com/AgentSmithers/x64DbgMCPServer/blob/master/Sample2
 
 ## Prerequisites
 To build and run this project, you'll need:
-Visual Studio Build Tools (2019 v16.7 or later)
-.NET Framework 4.7.2 SDK
+- Visual Studio Build Tools (2019 v16.7 or later)
+- .NET Framework 4.7.2 SDK
+- 3F/DllExport
 
 ## Getting Started
 Clone or fork the project: git clone https://github.com/AgentSmithers/x64DbgMCPServer
 
+Download [DLlExport.bat](https://github.com/3F/DllExport/releases/download/1.8/DllExport.bat) and place it in the root folder of the project. Then, run the `DllExport.bat`.
+
+In the DllExport GUI,
+1. Check the `Installed` checkbox.
+2. Set the Namespace for DllExport to `System.Runtime.InteropServices`.
+3. Choose the target platform(`x64` or `x86`).
+4. Click Apply.
+
 Open the solution and build.
+
+📌 Tip: If you see `x64DbgMCPServer.dll` in the output folder, rename it to `x64DbgMCPServer.dp64` so that x64dbg can load the plugin.
 
 copy the files (x64DbgMCPServer\bin\x64\Debug) into the x64DBG plugin (x96\release\x64\plugins\x64DbgMCPServer) folder to run
 ![image](https://github.com/user-attachments/assets/8511452e-b65c-4bc8-83ff-885c384d0bbe)


### PR DESCRIPTION
Due to build and compatibility issues with `UnmanagedExports.Repack`, this PR introduces a switch to `DllExport`.

## Why

- On environments with Visual Studio 2019 (v16.11.46) and .NET Framework 4.7.2 SDK, the project builds successfully, but x64dbg crashes when attempting to load the resulting plugin.
- Upon analyzing the generated `x64DbgMCPServer.dp64`, several DllExport entries are found to be missing or broken, likely due to `UnmanagedExports.Repack`.
- Additionally, on Visual Studio 2022 (v17.13.6), the project fails to build due to compatibility issues with `UnmanagedExports.Repack`.

`UnmanagedExports.Repack` is outdated and no longer actively maintained.  
`DllExport` provides a alternative that is compatible with current build tools and works with x64/x86 exports.

## What

- Replaced `UnmanagedExports.Repack` with [3F/DllExport](https://github.com/3F/DllExport) for function exports
- Added step-by-step instructions for configuring `DllExport` in the README, including GUI setup

Let me know if you’d prefer an alternative approach or if any adjustments are needed!