### PR TITLE
Update MCP server URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Cursor Connection:
 {
   "mcpServers": {
     "AgentSmithers X64Dbg MCP Server": {
-      "url": "http://127.0.0.1:50300/sse"
+      "url": "http://127.0.0.1:3001/sse"
     }
   }
 }


### PR DESCRIPTION
The README states the MCP server listens on port `50300`, but the plugin actually uses port `3001`.

When the plugin loads, the x64dbg log shows:

```
MCP server listening on +:3001
```

Connections to port 50300 fail, while port 3001 works correctly on Cursor.

The README Cursor section URL should be updated to use http://127.0.0.1:3001/sse instead of port 50300.