### PR TITLE
Add configurable MCP server IP address and port instead of hard coded http://127.0.0.1:50300/sse

### DIFF
--- a/DotNetPlugin.Impl/MCPServer.cs
+++ b/DotNetPlugin.Impl/MCPServer.cs
@@ -19,6 +19,7 @@ namespace DotNetPlugin
         private readonly HttpListener _listener = new HttpListener();
         private readonly Dictionary<string, MethodInfo> _commands = new Dictionary<string, MethodInfo>(StringComparer.OrdinalIgnoreCase);
         private readonly Type _targetType;
+        private readonly McpServerConfig _config;
 
         public bool IsActivelyDebugging
         {
@@ -26,14 +27,22 @@ namespace DotNetPlugin
             set { /* accept assignments from event callbacks; actual state comes from Bridge */ }
         }
 
-        public SimpleMcpServer(Type commandSourceType)
+        public SimpleMcpServer(Type commandSourceType) : this(commandSourceType, McpServerConfig.Load())
+        {
+        }
+
+        public SimpleMcpServer(Type commandSourceType, McpServerConfig config)
         {
             //DisableServerHeader(); //Prob not needed
             _targetType = commandSourceType;
-            string IPAddress = "+";
-            Console.WriteLine("MCP server lising on " + IPAddress);
-            _listener.Prefixes.Add("http://" + IPAddress + ":50300/sse/"); //Request come in without a trailing '/' but are still handled
-            _listener.Prefixes.Add("http://" + IPAddress + ":50300/message/");
+            _config = config ?? McpServerConfig.Load();
+            
+            string baseUrl = _config.GetBaseUrl();
+            Console.WriteLine($"MCP server listening on {baseUrl}");
+            Console.WriteLine($"Connect via: {_config.GetDisplayUrl()}");
+            
+            _listener.Prefixes.Add($"{baseUrl}sse/"); //Request come in without a trailing '/' but are still handled
+            _listener.Prefixes.Add($"{baseUrl}message/");
 
             //_listener.Prefixes.Add("http://127.0.0.1:50300/sse/"); //Request come in without a trailing '/' but are still handled
             //_listener.Prefixes.Add("http://127.0.0.1:50300/message/");
@@ -979,6 +988,6 @@ namespace DotNetPlugin
 
 
 
-
+       
     }
 }

--- a/DotNetPlugin.Impl/McpConfigDialog.cs
+++ b/DotNetPlugin.Impl/McpConfigDialog.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace DotNetPlugin
+{
+    /// <summary>
+    /// Configuration dialog for the MCP server settings.
+    /// Allows users to configure the IP address and port for the HTTP listener.
+    /// </summary>
+    public class McpConfigDialog : Form
+    {
+        private TextBox txtIpAddress;
+        private NumericUpDown numPort;
+        private Button btnSave;
+        private Button btnCancel;
+        private Label lblHelp;
+        private Label lblCurrentUrl;
+
+        public string IpAddress => txtIpAddress.Text.Trim();
+        public int Port => (int)numPort.Value;
+
+        public McpConfigDialog(McpServerConfig currentConfig)
+        {
+            InitializeComponents(currentConfig);
+            UpdateUrlPreview();
+        }
+
+        private void InitializeComponents(McpServerConfig config)
+        {
+            // Form settings
+            Text = "MCP Server Configuration";
+            Width = 420;
+            Height = 280;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            StartPosition = FormStartPosition.CenterParent;
+            MaximizeBox = false;
+            MinimizeBox = false;
+
+            // IP Address Label
+            var lblIp = new Label
+            {
+                Text = "IP Address:",
+                Left = 15,
+                Top = 20,
+                Width = 80,
+                TextAlign = ContentAlignment.MiddleRight
+            };
+
+            // IP Address TextBox
+            txtIpAddress = new TextBox
+            {
+                Left = 100,
+                Top = 18,
+                Width = 180,
+                Text = config.IpAddress
+            };
+            txtIpAddress.TextChanged += (s, e) => UpdateUrlPreview();
+
+            // IP Help Label
+            var lblIpHelp = new Label
+            {
+                Text = "(+, *, localhost, or IP)",
+                Left = 285,
+                Top = 20,
+                Width = 110,
+                ForeColor = Color.Gray,
+                Font = new Font(Font.FontFamily, 8)
+            };
+
+            // Port Label
+            var lblPort = new Label
+            {
+                Text = "Port:",
+                Left = 15,
+                Top = 55,
+                Width = 80,
+                TextAlign = ContentAlignment.MiddleRight
+            };
+
+            // Port NumericUpDown
+            numPort = new NumericUpDown
+            {
+                Left = 100,
+                Top = 53,
+                Width = 100,
+                Minimum = 1,
+                Maximum = 65535,
+                Value = config.Port
+            };
+            numPort.ValueChanged += (s, e) => UpdateUrlPreview();
+
+            // URL Preview Label
+            var lblUrlTitle = new Label
+            {
+                Text = "Server URL:",
+                Left = 15,
+                Top = 95,
+                Width = 80,
+                TextAlign = ContentAlignment.MiddleRight
+            };
+
+            lblCurrentUrl = new Label
+            {
+                Left = 100,
+                Top = 95,
+                Width = 280,
+                Height = 20,
+                ForeColor = Color.DarkBlue,
+                Font = new Font(Font.FontFamily, 9, FontStyle.Bold)
+            };
+
+            // Help text
+            lblHelp = new Label
+            {
+                Left = 15,
+                Top = 125,
+                Width = 375,
+                Height = 60,
+                Text = "Notes:\n" +
+                       "• Use '+' or '*' to listen on all interfaces (requires admin or urlacl)\n" +
+                       "• Use '127.0.0.1' or 'localhost' for local-only access\n" +
+                       "• Restart the MCP server after changing settings",
+                ForeColor = Color.DimGray,
+                Font = new Font(Font.FontFamily, 8)
+            };
+
+            // Save Button
+            btnSave = new Button
+            {
+                Text = "Save",
+                Left = 210,
+                Top = 195,
+                Width = 85,
+                Height = 30,
+                DialogResult = DialogResult.OK
+            };
+            btnSave.Click += BtnSave_Click;
+
+            // Cancel Button
+            btnCancel = new Button
+            {
+                Text = "Cancel",
+                Left = 305,
+                Top = 195,
+                Width = 85,
+                Height = 30,
+                DialogResult = DialogResult.Cancel
+            };
+
+            // Add controls
+            Controls.AddRange(new Control[]
+            {
+                lblIp, txtIpAddress, lblIpHelp,
+                lblPort, numPort,
+                lblUrlTitle, lblCurrentUrl,
+                lblHelp,
+                btnSave, btnCancel
+            });
+
+            AcceptButton = btnSave;
+            CancelButton = btnCancel;
+        }
+
+        private void UpdateUrlPreview()
+        {
+            string ip = string.IsNullOrWhiteSpace(txtIpAddress.Text) ? "+" : txtIpAddress.Text.Trim();
+            string displayIp = (ip == "+" || ip == "*") ? "127.0.0.1" : ip;
+            lblCurrentUrl.Text = $"http://{displayIp}:{(int)numPort.Value}/sse";
+        }
+
+        private void BtnSave_Click(object sender, EventArgs e)
+        {
+            // Validate IP address
+            if (!McpServerConfig.IsValidIpAddress(txtIpAddress.Text.Trim()))
+            {
+                MessageBox.Show(
+                    "Invalid IP address format.\n\nValid values:\n• + (all interfaces)\n• * (all interfaces)\n• localhost\n• A valid IP address (e.g., 127.0.0.1, 192.168.1.100)",
+                    "Validation Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+                txtIpAddress.Focus();
+                txtIpAddress.SelectAll();
+                DialogResult = DialogResult.None;
+                return;
+            }
+
+            // Port validation is handled by NumericUpDown control
+            DialogResult = DialogResult.OK;
+        }
+    }
+}

--- a/DotNetPlugin.Impl/McpServerConfig.cs
+++ b/DotNetPlugin.Impl/McpServerConfig.cs
@@ -1,0 +1,133 @@
+using System;
+using System.IO;
+using System.Web.Script.Serialization;
+
+namespace DotNetPlugin
+{
+    /// <summary>
+    /// Configuration for the MCP server including IP address and port settings.
+    /// Settings are persisted to a JSON file in the plugin directory.
+    /// </summary>
+    public class McpServerConfig
+    {
+        public string IpAddress { get; set; } = "+";
+        public int Port { get; set; } = 50300;
+
+        private static string _configPath;
+
+        /// <summary>
+        /// Gets the path to the configuration file in the plugin directory.
+        /// </summary>
+        public static string ConfigPath
+        {
+            get
+            {
+                if (_configPath == null)
+                {
+                    var assemblyDir = Path.GetDirectoryName(typeof(McpServerConfig).Assembly.Location);
+                    _configPath = Path.Combine(assemblyDir, "mcp_config.json");
+                }
+                return _configPath;
+            }
+        }
+
+        /// <summary>
+        /// Gets the base URL for the HTTP listener (e.g., "http://+:50300/").
+        /// </summary>
+        public string GetBaseUrl()
+        {
+            return $"http://{IpAddress}:{Port}/";
+        }
+
+        /// <summary>
+        /// Gets the SSE endpoint URL for display purposes.
+        /// </summary>
+        public string GetDisplayUrl()
+        {
+            string displayIp = IpAddress == "+" ? "127.0.0.1" : IpAddress;
+            return $"http://{displayIp}:{Port}/sse";
+        }
+
+        /// <summary>
+        /// Loads the configuration from the JSON file, or returns default settings if the file doesn't exist.
+        /// </summary>
+        public static McpServerConfig Load()
+        {
+            try
+            {
+                if (File.Exists(ConfigPath))
+                {
+                    var json = File.ReadAllText(ConfigPath);
+                    var serializer = new JavaScriptSerializer();
+                    var config = serializer.Deserialize<McpServerConfig>(json);
+                    if (config != null)
+                    {
+                        // Validate loaded values
+                        if (string.IsNullOrWhiteSpace(config.IpAddress))
+                            config.IpAddress = "+";
+                        if (config.Port < 1 || config.Port > 65535)
+                            config.Port = 50300;
+                        return config;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[McpServerConfig] Error loading config: {ex.Message}. Using defaults.");
+            }
+
+            return new McpServerConfig();
+        }
+
+        /// <summary>
+        /// Saves the current configuration to the JSON file.
+        /// </summary>
+        public void Save()
+        {
+            try
+            {
+                var serializer = new JavaScriptSerializer();
+                var json = serializer.Serialize(this);
+
+                // Ensure directory exists
+                var dir = Path.GetDirectoryName(ConfigPath);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                File.WriteAllText(ConfigPath, json);
+                Console.WriteLine($"[McpServerConfig] Configuration saved to: {ConfigPath}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[McpServerConfig] Error saving config: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Validates the IP address format.
+        /// </summary>
+        public static bool IsValidIpAddress(string ip)
+        {
+            if (string.IsNullOrWhiteSpace(ip))
+                return false;
+
+            // Special values for HttpListener
+            if (ip == "+" || ip == "*" || ip == "localhost")
+                return true;
+
+            // Check for valid IP address format
+            System.Net.IPAddress address;
+            return System.Net.IPAddress.TryParse(ip, out address);
+        }
+
+        /// <summary>
+        /// Validates the port number.
+        /// </summary>
+        public static bool IsValidPort(int port)
+        {
+            return port >= 1 && port <= 65535;
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR adds the ability to configure the MCP server's IP address and port through a plugin UI dialog, replacing the previously hardcoded `http://+:50300/sse` URL.

## Changes

### New Files
* `McpServerConfig.cs` - Configuration class that stores IP address and port settings, with JSON persistence to `mcp_config.json` in the plugin directory.
* `McpConfigDialog.cs` - Windows Forms dialog for configuring settings via the plugin menu.

### Modified Files
* `MCPServer.cs` - Updated `SimpleMcpServer` constructor to accept `McpServerConfig` parameter for configurable HTTP listener URL.
* `Plugin.Commands.cs` - Updated `cbStartMCPServer` to load and use configuration; added `GetMcpServerConfig()` and `SetMcpServerConfig()` helper methods.
* `Plugin.Menus.cs` - Added "Configure MCP Server..." menu item under Plugins menu.

## Features
* **Persistent Configuration:** Settings are saved to `mcp_config.json` and persist across sessions.
* **UI Configuration Dialog:** Accessible via **Plugins → Configure MCP Server...**
<img width="413" height="124" alt="image" src="https://github.com/user-attachments/assets/50465c3b-54f4-42cc-b25c-be307727a9db" />
* **Live URL Preview:** Dialog shows real-time preview of the configured URL.
<img width="424" height="293" alt="image" src="https://github.com/user-attachments/assets/1ca5266e-93d5-44da-82e0-f3effcd0bbbd" />
* **Input Validation:** Validates IP address format before saving.

## Supported IP Address Values

| Value | Behavior |
|-------|----------|
| `+` or `*` | Listen on all interfaces (requires admin privileges or `urlacl`) |
| `127.0.0.1` or `localhost` | Local-only access (no admin required) |
| Specific IP (e.g., `192.168.1.100`) | Listen on specific network interface |

## Usage
1. Open x64dbg with the plugin loaded.
2. Go to **Plugins → Configure MCP Server...**
3. Enter desired IP address and port.
4. Click **Save**.
5. Restart the MCP server (Stop then Start) for changes to take effect.

## Testing
- [x] Build succeeds with no errors
- [x] Configuration dialog opens and displays correctly
- [x] Settings persist after closing and reopening x64dbg
- [x] Server starts with configured IP/port
<img width="478" height="101" alt="image" src="https://github.com/user-attachments/assets/455aea3c-f723-47f2-a5a6-e5d5fd5d9687" />
<img width="678" height="76" alt="image" src="https://github.com/user-attachments/assets/2cf0c4c7-3ddb-4c63-bc6b-e41c2a5556c3" />

## Breaking Changes
None. Default values (`+:50300`) match the previous hardcoded behavior.