### PR TITLE
Fix config save failure when Impl assembly is loaded from memory

### DIFF
--- a/DotNetPlugin.Impl/DotNetPlugin.Impl.csproj
+++ b/DotNetPlugin.Impl/DotNetPlugin.Impl.csproj
@@ -11,6 +11,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyTitle>$(PluginName)</AssemblyTitle>
     <BaseOutputPath>bin</BaseOutputPath>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)'=='x86'">
@@ -34,6 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.18.2" />
+    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />
     <PackageReference Include="UnmanagedExports.Repack" Version="1.0.4">
       <IncludeAssets>build</IncludeAssets>

--- a/DotNetPlugin.Impl/McpServerConfig.cs
+++ b/DotNetPlugin.Impl/McpServerConfig.cs
@@ -15,6 +15,23 @@ namespace DotNetPlugin
 
         private static string _configPath;
 
+        private static string ResolveConfigDirectory()
+        {
+            var assemblyLocation = typeof(McpServerConfig).Assembly.Location;
+            if (!string.IsNullOrWhiteSpace(assemblyLocation))
+            {
+                var assemblyDir = Path.GetDirectoryName(assemblyLocation);
+                if (!string.IsNullOrWhiteSpace(assemblyDir))
+                    return assemblyDir;
+            }
+
+            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            if (!string.IsNullOrWhiteSpace(baseDirectory))
+                return baseDirectory;
+
+            return Environment.CurrentDirectory;
+        }
+
         /// <summary>
         /// Gets the path to the configuration file in the plugin directory.
         /// </summary>
@@ -24,8 +41,7 @@ namespace DotNetPlugin
             {
                 if (_configPath == null)
                 {
-                    var assemblyDir = Path.GetDirectoryName(typeof(McpServerConfig).Assembly.Location);
-                    _configPath = Path.Combine(assemblyDir, "mcp_config.json");
+                    _configPath = Path.Combine(ResolveConfigDirectory(), "mcp_config.json");
                 }
                 return _configPath;
             }


### PR DESCRIPTION
McpServerConfig previously relied on Assembly.Location to build the
config file path. In debug/unloadable mode, the Impl assembly may be
loaded from memory, which can leave Assembly.Location empty and cause
"The path is not of a legal form." when saving config.

Fall back to AppDomain.CurrentDomain.BaseDirectory and then
Environment.CurrentDirectory when the assembly path is unavailable.